### PR TITLE
Use Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
-RUN apk --update --no-cache add curl python3 python3-dev ca-certificates \
+RUN apk --update --no-cache add curl python3 python3-dev py3-pip ca-certificates \
 	&& adduser -D -h /home/container container
 RUN npm i --no-audit ghost-cli@latest -g
 

--- a/egg-ghost.json
+++ b/egg-ghost.json
@@ -16,7 +16,7 @@
     "scripts": {
         "installation": {
             "script": "apk --no-cache add git\r\ncd \/mnt\/server\/\r\ngit clone https:\/\/github.com\/razboy20\/pterodactyl-ghost .\/temp\r\nchmod +x .\/temp\/install.sh\r\n\r\n.\/temp\/install.sh\r\n\r\nrm -rf .\/temp",
-            "container": "node:18-alpine",
+            "container": "node:22-alpine",
             "entrypoint": "ash"
         }
     },

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 cd /mnt/server
 
-apk --no-cache add sudo curl
+apk --no-cache add sudo curl python3 py3-pip
 apk add --no-cache 'su-exec>=0.2'
 
 npm i --no-audit ghost-cli@latest -g

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,9 @@
 # echo "Starting PHP-FPM..."
 # /usr/sbin/php-fpm7 --fpm-config /home/container/php-fpm/php-fpm.conf --daemonize
 
+# The binaries otherwise mismatch and Ghost will fail to start
+npm install sqlite3 --save
+
 echo "Starting Ghost..."
 cd ./ghost && ghost start &
 ./caddy-server run --watch --config ./caddy/Caddyfile


### PR DESCRIPTION
Looks like Ghost made some changes at some point, requiring newer versions and pip to install some dependencies for SQLite 